### PR TITLE
React-native 0.56 compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,33 +1,25 @@
-
-buildscript {
-    repositories {
-        jcenter()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.1'
-    }
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
 
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion safeExtGet('compileSdkVersion', 26)
+    buildToolsVersion safeExtGet('buildToolsVersion', '26.0.3')
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('minSdkVersion', 26)
         versionCode 1
         versionName "1.0"
+        ndk {
+            abiFilters "armeabi-v7a", "x86"
+        }
     }
     lintOptions {
         abortOnError false
     }
-}
-
-repositories {
-    mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
React-native 0.56 compatibility with updated version of compile and  build android tools an sdk. 

Allow to overrided  by specifying `ext` with specific version in root `build.gradle`.
ext {
    compileSdkVersion   = 26
    buildToolsVersion   = "26.0.2"
    targetSdkVersion    = 26
}